### PR TITLE
corrected a typo in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,5 @@ setup(name='sslstrip',
       packages=["sslstrip"],
       package_dir={'sslstrip': 'sslstrip/'},
       scripts=['sslstrip/sslstrip'],
-      data_files=[('share/sslstrip', ['README', 'COPYING', 'lock.ico'])],
+      data_files=[('share/sslstrip', ['README.md', 'COPYING', 'lock.ico'])],
       )


### PR DESCRIPTION
`setup.py` had a typo with `README` file which caused an error that `README` was not recognizable or didn't exist if the `install` flag was used with the `setup.py` file. I have changed the `README` to `README.md` inside the file and the script works fine now.