### PR TITLE
Add extension

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,5 @@ setup(name='sslstrip',
       packages=["sslstrip"],
       package_dir={'sslstrip': 'sslstrip/'},
       scripts=['sslstrip/sslstrip'],
-      data_files=[('share/sslstrip', ['README', 'COPYING', 'lock.ico'])],
+      data_files=[('share/sslstrip', ['README.md', 'COPYING', 'lock.ico'])],
       )


### PR DESCRIPTION
Build process fails otherwise.

```bash
[...]
copying build/lib/sslstrip/URLMonitor.py -> build/bdist.linux-x86_64/wheel/sslstrip
running install_data
creating build/bdist.linux-x86_64/wheel/sslstrip-2.0.data
creating build/bdist.linux-x86_64/wheel/sslstrip-2.0.data/data
creating build/bdist.linux-x86_64/wheel/sslstrip-2.0.data/data/share
creating build/bdist.linux-x86_64/wheel/sslstrip-2.0.data/data/share/sslstrip
error: can't copy 'README': doesn't exist or not a regular file

ERROR Backend subprocess exited when trying to invoke build_wheel
```